### PR TITLE
Updated handling of assignment expanding

### DIFF
--- a/src/routes/home/+page.svelte
+++ b/src/routes/home/+page.svelte
@@ -204,7 +204,7 @@
      */
     function handleExpandClick(index, e) {
         e.stopPropagation();
-        expandedAssignment = toggleAssignmentDetails(expandedAssignment, index, e);
+        !e.target.closest('.assignment-details-wrapper') ? expandedAssignment = toggleAssignmentDetails(expandedAssignment, index, e) : null;
     }
 
     /**
@@ -217,10 +217,6 @@
      * @returns {Promise<void>}
      */
     function toggleAssignmentDetails(expandedAssignment, index, e) {
-        if (e.target.closest('.assignment-details-wrapper')) {
-            return null;
-        }
-
         return expandedAssignment === index ? null : index;
     }
 


### PR DESCRIPTION
Updated handling of assignment expand click so it only collapses the assignment when the assignment is actual clicked instead of it's contents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved interaction when expanding assignment details. Now, clicks within the detail area no longer trigger an unintended expansion, ensuring a more predictable and user-friendly display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->